### PR TITLE
ListReaders.java: add missing imports

### DIFF
--- a/examples/de/intarsys/security/smartcard/pcsc/ListReaders.java
+++ b/examples/de/intarsys/security/smartcard/pcsc/ListReaders.java
@@ -2,6 +2,10 @@ package de.intarsys.security.smartcard.pcsc;
 
 import java.util.List;
 
+import de.intarsys.security.smartcard.pcsc.IPCSCCardReader;
+import de.intarsys.security.smartcard.pcsc.IPCSCContext;
+import de.intarsys.security.smartcard.pcsc.PCSCContextFactory;
+
 public class ListReaders {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
I don't know how the sample code can compile without the imports.